### PR TITLE
Add word-wrap to <pre>-tagged text

### DIFF
--- a/docs/cnntp/css/cnntp.css
+++ b/docs/cnntp/css/cnntp.css
@@ -25,3 +25,11 @@
  .lighter { color: #777 }
  .small  { font-size: 85% }
 
+ pre {
+   overflow-x: auto;
+   white-space: pre-wrap;
+   white-space: -moz-pre-wrap;
+   white-space: -pre-wrap;
+   white-space: -o-pre-wrap;
+   word-wrap: break-word;
+ }


### PR DESCRIPTION
This adds some CSS directives that will wrap text in `<pre>` blocks -- and thus all the body text of displayed NNTP messages.

The proposed CSS code is copied from this article: <https://www.w3docs.com/snippets/css/how-to-wrap-text-in-a-pre-tag-with-css.html>

I have tested this using locally loaded stylesheets, and I find that this vastly improves readability of messages in a typical modern web browser. Without it, one must manually scroll the view left and right in order to read any paragraphs longer than one screen-width.