### PR TITLE
Show "A message" when a messages title is invisible

### DIFF
--- a/docs/cnntp/tpl/article.html
+++ b/docs/cnntp/tpl/article.html
@@ -24,7 +24,9 @@
       link = thread.message.id != article.id;
    %]
     <li>[% IF link %]<!-- #[% thread.message.id %] --><a href="[% thread.message.uri %]">[% ELSE; '<b>'; END %]
-      [% thread.message.h_subject_parsed | html %][% link ? '</a>' : '</b>' %]
+      [% IF thread.message.h_subject_parsed.match('\S'); 
+        thread.message.h_subject_parsed | html %][% ELSE %]A message[% 
+      END %][% link ? '</a>' : '</b>' %]
       by [% thread.message.author_name | html %]</li> [%
    END;
    IF thread.child;


### PR DESCRIPTION
If some absolute madlad sends a reply to a list with no printable characters in the message subject the link to read the message is invisible and so quite difficult to click. 

"A message by authorname" seems like a reasonable stand-in

Without this patch (or one like it) one must open the inspector to click the link to the message from _redacted_: 
<img width="659" alt="Screen Shot 2023-06-23 at 12 33 10" src="https://github.com/perlorg/cnntp/assets/3603869/3770fc42-d8d7-42c8-916e-8b8b3520d409">

<!-- https://www.nntp.perl.org/group/perl.perl5.porters/2023/06/msg266509.html -->